### PR TITLE
Add configurable branch to autocommit.sh

### DIFF
--- a/autocommit.sh
+++ b/autocommit.sh
@@ -30,6 +30,10 @@ mainsail_folder=~/mainsail
 ### Path to your Fluidd folder, by default that is '~/fluidd'
 #fluidd_folder=~/fluidd
 
+### The branch of the repository that you want to save your config
+### By default that is 'master'
+branch=master
+
 #####################################################################
 #####################################################################
 
@@ -69,11 +73,11 @@ grab_version(){
 
 push_config(){
   cd $config_folder
-  git pull origin master
+  git pull origin $branch
   git add .
   current_date=$(date +"%Y-%m-%d %T")
   git commit -m "Autocommit from $current_date" -m "$m1" -m "$m2" -m "$m3" -m "$m4"
-  git push origin master
+  git push origin $branch
 }
 
 grab_version


### PR DESCRIPTION
Make the default branch as a configurable option, because the default branch of some newly
created repositories will be `main` instead of `master`