### PR TITLE
Add --no-rebase to autocommit.sh to avoid warning

### DIFF
--- a/autocommit.sh
+++ b/autocommit.sh
@@ -73,7 +73,7 @@ grab_version(){
 
 push_config(){
   cd $config_folder
-  git pull origin $branch
+  git pull origin $branch --no-rebase
   git add .
   current_date=$(date +"%Y-%m-%d %T")
   git commit -m "Autocommit from $current_date" -m "$m1" -m "$m2" -m "$m3" -m "$m4"


### PR DESCRIPTION
Without `--no-rebase` you get the warning

```
hint: Pulling without specifying how to reconcile divergent branches is
hint: discouraged. You can squelch this message by running one of the following
hint: commands sometime before your next pull:
hint:
hint: git config pull.rebase false # merge (the default strategy)
hint: git config pull.rebase true # rebase
hint: git config pull.ff only # fast-forward only
hint:
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
```

`--no-rebase` is `the default strategy`