### PR TITLE
Update autocommit.sh to automatically delete the moonraker-sql.db

### DIFF
--- a/autocommit.sh
+++ b/autocommit.sh
@@ -91,5 +91,11 @@ push_config(){
   git push origin $branch
 }
 
+cleanup_database(){
+  cd $config_folder
+  rm moonraker-sql.db
+}
+
 grab_version
 push_config
+cleanup_database


### PR DESCRIPTION
Update autocommit.sh to automatically delete the moonraker-sql.db after a backup has been completed so it does not stay around in the Mainsail or Fluid web UI.